### PR TITLE
Do not require users to provide miss_track_file

### DIFF
--- a/misp_import.py
+++ b/misp_import.py
@@ -144,7 +144,7 @@ def main():
         "actors_unique_tag": settings["CrowdStrike"]["actors_unique_tag"],
         "unknown_mapping": settings["CrowdStrike"]["unknown_mapping"],
         "max_threads": settings["MISP"].get("max_threads", None),
-        "miss_track_file": settings["MISP"]["miss_track_file"],
+        "miss_track_file": settings["MISP"].get("miss_track_file", "no_galaxy_mapping.log"),
         "misp_enable_ssl": False if "F" in settings["MISP"]["misp_enable_ssl"].upper() else True
     }
     if not import_settings["unknown_mapping"]:


### PR DESCRIPTION
Addressing:
```
Traceback (most recent call last):
  File "/misp_import.py", line 189, in <module>
    main()
  File "/misp_import.py", line 147, in main
    "miss_track_file": settings["MISP"]["miss_track_file"],
  File "/usr/local/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/configparser.py", line 1257, in __getitem__
    raise KeyError(key)
KeyError: 'miss_track_file'
```