### PR TITLE
Fix date format in Win environments. Closes #15.

### DIFF
--- a/cs_misp_import/indicators.py
+++ b/cs_misp_import/indicators.py
@@ -77,8 +77,12 @@ class IndicatorsImporter:
         :param indicators_days_before: in case on an initial run, this is the age of the indicators pulled in days
         :param events_already_imported: the events already imported in misp, to avoid duplicates
         """
-        start_get_events = int((datetime.date.today() - datetime.timedelta(indicators_days_before)).strftime("%s"))
-        #start_get_events = int((datetime.date.today() - datetime.timedelta(hours=indicators_days_before)).strftime("%s"))
+        start_get_events = int(
+            datetime.datetime.combine(
+                datetime.date.today() - datetime.timedelta(days=indicators_days_before),
+                datetime.time()
+                ).timestamp()
+            )
         if os.path.isfile(self.indicators_timestamp_filename):
             with open(self.indicators_timestamp_filename, 'r', encoding="utf-8") as ts_file:
                 line = ts_file.readline()


### PR DESCRIPTION
This update resolves a date formatting issue impacting Windows environments. (`%s` is not a valid Python formatting string, which results in an error when the format cannot be retrieved from the OS.)