### PR TITLE
Fixes error when there are no reports returned

### DIFF
--- a/cs_misp_import/intel_client.py
+++ b/cs_misp_import/intel_client.py
@@ -59,7 +59,9 @@ class IntelAPIClient:
             offset += resp_json.get('meta', {}).get('pagination', {}).get('limit', 5000)
             first_run = False
 
-            reports.extend(resp_json.get('resources', []))
+            resources = resp_json.get('resources', [])
+            if resources is not None and len(resources) > 0:
+                reports.extend(resp_json.get('resources', []))
 
         return reports
 

--- a/cs_misp_import/intel_client.py
+++ b/cs_misp_import/intel_client.py
@@ -60,7 +60,7 @@ class IntelAPIClient:
             first_run = False
 
             resources = resp_json.get('resources', [])
-            if resources is not None and len(resources) > 0:
+            if resources:
                 reports.extend(resp_json.get('resources', []))
 
         return reports


### PR DESCRIPTION
Fixes

```
intel_client.py", line 62, in get_reports
    reports.extend(resp_json.get('resources', []))
TypeError: 'NoneType' object is not iterable
```